### PR TITLE
adding scopes to customize permissions needed for each view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Critical items to know are:
  - changed behaviour
 
 ## [master](https://github.com/vsoch/django-oci/tree/master)
+ - View specific permission (pull,push) required (0.0.13)
  - Adding Django ratelimit to protect views (0.0.12)
  - Added authentication (0.0.11)
  - Django OCI core release without authentication (0.0.1)

--- a/django_oci/__init__.py
+++ b/django_oci/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 default_app_config = "django_oci.apps.DjangoOciConfig"

--- a/django_oci/auth.py
+++ b/django_oci/auth.py
@@ -36,7 +36,7 @@ import jwt
 
 
 def is_authenticated(
-    request, repository=None, must_be_owner=True, repository_exists=True
+    request, repository=None, must_be_owner=True, repository_exists=True, scopes=None
 ):
     """
     Function to check if a request is authenticated, a repository and the request is required.
@@ -51,6 +51,9 @@ def is_authenticated(
     must_be_owner (bool)          : if must be owner is true, requires push
     reposity_exists (bool)        : flag to indicate that the repository exists.
     """
+    # Scopes default to push and pull, more conservative
+    scopes = scopes or ["push", "pull"]
+
     # Derive the view name from the request PATH_INFO
     func, two, three = resolve(request.META["PATH_INFO"])
     view_name = "%s.%s" % (func.__module__, func.__name__)
@@ -76,7 +79,7 @@ def is_authenticated(
     # Case 3: False and response will return request for auth
     user = get_user(request)
     if not user:
-        headers = {"Www-Authenticate": get_challenge(request, name)}
+        headers = {"Www-Authenticate": get_challenge(request, name, scopes=scopes)}
         return False, Response(status=401, headers=headers), user
 
     # Denied for any other reason

--- a/django_oci/views/blobs.py
+++ b/django_oci/views/blobs.py
@@ -57,7 +57,7 @@ class BlobDownload(APIView):
         digest = kwargs.get("digest")
 
         # If allow_continue False, return response
-        allow_continue, response, _ = is_authenticated(request, name)
+        allow_continue, response, _ = is_authenticated(request, name, scopes=["pull"])
         if not allow_continue:
             return response
 

--- a/django_oci/views/image.py
+++ b/django_oci/views/image.py
@@ -60,7 +60,9 @@ class ImageTags(APIView):
             raise Http404
 
         # If allow_continue False, return response
-        allow_continue, response, _ = is_authenticated(request, repository)
+        allow_continue, response, _ = is_authenticated(
+            request, repository, scopes=["pull"]
+        )
         if not allow_continue:
             return response
 
@@ -213,7 +215,7 @@ class ImageManifest(APIView):
         tag = kwargs.get("tag")
 
         # If allow_continue False, return response
-        allow_continue, response, _ = is_authenticated(request, name)
+        allow_continue, response, _ = is_authenticated(request, name, scopes=["pull"])
         if not allow_continue:
             return response
 


### PR DESCRIPTION
Currently, all views require push and pull, however the get_challenge function exposes an argument to customize this. With the knowledge that push is equivalent to write (and the requestor must be an owner of the repository) and pull is equivalent to read (and doesn't need to be) this updates views with permissions, namely GET requests for image manifests, blobs, and tags only require a `pull` permission.

Signed-off-by: vsoch <vsochat@stanford.edu>